### PR TITLE
Take type into account for scrum entry unique constraint

### DIFF
--- a/server/src/migrations/2024-10-25-1330_scrum_entry_unique.ts
+++ b/server/src/migrations/2024-10-25-1330_scrum_entry_unique.ts
@@ -1,0 +1,34 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>) {
+	await db.schema
+		.alterTable("scrum_entries")
+		.dropConstraint("scrum_entries_unique")
+		.execute();
+
+	await db.schema
+		.alterTable("scrum_entries")
+		.addUniqueConstraint("scrum_entries_unique", [
+			"scrum_id",
+			"member_id",
+			"type",
+			"order",
+		])
+		.execute();
+}
+
+export async function down(db: Kysely<any>) {
+	await db.schema
+		.alterTable("scrum_entries")
+		.dropConstraint("scrum_entries_unique")
+		.execute();
+
+	await db.schema
+		.alterTable("scrum_entries")
+		.addUniqueConstraint("scrum_entries_unique", [
+			"scrum_id",
+			"member_id",
+			"order",
+		])
+		.execute();
+}


### PR DESCRIPTION
Without this, scrum entries with the same order for different categories will falsely trigger the constraint.