### PR TITLE
Add form UI for scrum fields

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
 		"react-script-hook": "^1.7.2"
 	},
 	"devDependencies": {
+		"@tailwindcss/forms": "^0.5.9",
 		"@tanstack/router-devtools": "^1.35.3",
 		"@tanstack/router-vite-plugin": "^1.34.8",
 		"@types/google.accounts": "^0.0.14",

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -66,9 +66,10 @@ export const TextArea = (props: TextAreaProps) => {
 		}
 	};
 
+	// Exciting Chromium bug: the text area will always render a small bottom margin unless you set display: block. https://issues.chromium.org/issues/41420646#comment12
 	return (
 		<textarea
-			className={`bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white ${fontSizeClass}`}
+			className={`bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white ${fontSizeClass} box-border block`}
 			ref={ref}
 			value={localValue}
 			disabled={disabled}

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -1,0 +1,21 @@
+type TextAreaProps = {
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+};
+
+export const TextArea = (props: TextAreaProps) => {
+	const { value, onChange, placeholder } = props;
+
+	return (
+		<textarea
+			className="text-2xl bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white"
+			value={value}
+			onChange={(e) => {
+				onChange(e.currentTarget.value);
+			}}
+			placeholder={placeholder}
+			rows={1}
+		/>
+	);
+};

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -1,15 +1,29 @@
+export type TextAreaSize = "large" | "default";
+
 type TextAreaProps = {
 	value: string;
+	size: TextAreaSize;
 	onChange: (value: string) => void;
 	placeholder?: string;
 };
 
+const getFontSizeClass = (size: TextAreaSize) => {
+	switch (size) {
+		case "large":
+			return "text-2xl";
+		case "default":
+			return "";
+	}
+};
+
 export const TextArea = (props: TextAreaProps) => {
-	const { value, onChange, placeholder } = props;
+	const { value, onChange, placeholder, size } = props;
+
+	const fontSizeClass = getFontSizeClass(size);
 
 	return (
 		<textarea
-			className="text-2xl bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white"
+			className={`bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white ${fontSizeClass}`}
 			value={value}
 			onChange={(e) => {
 				onChange(e.currentTarget.value);

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -7,6 +7,7 @@ type TextAreaProps = {
 	size: TextAreaSize;
 	onChange: (value: string) => void;
 	placeholder?: string;
+	disabled?: boolean;
 };
 
 const getFontSizeClass = (size: TextAreaSize) => {
@@ -19,7 +20,7 @@ const getFontSizeClass = (size: TextAreaSize) => {
 };
 
 export const TextArea = (props: TextAreaProps) => {
-	const { value, onChange, placeholder, size } = props;
+	const { value, onChange, placeholder, size, disabled } = props;
 
 	const fontSizeClass = getFontSizeClass(size);
 
@@ -67,6 +68,7 @@ export const TextArea = (props: TextAreaProps) => {
 			className={`bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white ${fontSizeClass}`}
 			ref={ref}
 			value={localValue}
+			disabled={disabled}
 			onChange={(e) => {
 				setLocalValue(e.currentTarget.value);
 			}}

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -7,6 +7,7 @@ type TextAreaProps = {
 	size: TextAreaSize;
 	onChange: (value: string) => void;
 	placeholder?: string;
+	allowNewlines?: boolean;
 	disabled?: boolean;
 };
 
@@ -20,7 +21,7 @@ const getFontSizeClass = (size: TextAreaSize) => {
 };
 
 export const TextArea = (props: TextAreaProps) => {
-	const { value, onChange, placeholder, size, disabled } = props;
+	const { value, onChange, placeholder, size, disabled, allowNewlines } = props;
 
 	const fontSizeClass = getFontSizeClass(size);
 
@@ -57,7 +58,9 @@ export const TextArea = (props: TextAreaProps) => {
 
 	const onEnterKeyPressed = (e: React.KeyboardEvent) => {
 		if (e.shiftKey) {
-			insertNewline();
+			if (allowNewlines) {
+				insertNewline();
+			}
 		} else {
 			submit();
 		}

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 export type TextAreaSize = "large" | "default";
 
 type TextAreaProps = {
@@ -21,9 +23,24 @@ export const TextArea = (props: TextAreaProps) => {
 
 	const fontSizeClass = getFontSizeClass(size);
 
+	const ref = useRef<HTMLTextAreaElement | null>(null);
+
+	// Clever trick to autosize the textarea from here: https://medium.com/@oherterich/creating-a-textarea-with-dynamic-height-using-react-and-typescript-5ed2d78d9848
+	// biome-ignore lint/correctness/useExhaustiveDependencies: We need to recalc height when the value changes, even if we don't use it.
+	useEffect(() => {
+		const { current: textArea } = ref;
+		if (textArea) {
+			textArea.style.height = "0px";
+			const scrollHeight = textArea.scrollHeight;
+
+			textArea.style.height = `${scrollHeight}px`;
+		}
+	}, [ref, value]);
+
 	return (
 		<textarea
 			className={`bg-secondary border-none w-full resize-none focus:ring-0 focus:bg-white ${fontSizeClass}`}
+			ref={ref}
 			value={value}
 			onChange={(e) => {
 				onChange(e.currentTarget.value);

--- a/client/src/components/TextArea.tsx
+++ b/client/src/components/TextArea.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type TextAreaSize = "large" | "default";
 

--- a/client/src/components/scrum/ScrumTabMain.tsx
+++ b/client/src/components/scrum/ScrumTabMain.tsx
@@ -1,5 +1,4 @@
 import type { ScrumGetResponse } from "@scr4m/common";
-import { useState } from "react";
 import { TextArea } from "../TextArea";
 
 export type ScrumTabMainTitle = {
@@ -9,15 +8,13 @@ export type ScrumTabMainTitle = {
 const ScrumTabMainTitle = (props: ScrumTabMainTitle) => {
 	const { scrum } = props;
 
-	const [title, setTitle] = useState<string>(scrum.title);
-
 	return (
 		<>
 			<h1 className="text-8xl mb-3">Scrum #{scrum.number}</h1>
 			<div className="text-2xl">
 				<TextArea
-					value={title}
-					onChange={setTitle}
+					value={scrum.title}
+					onChange={() => {}}
 					placeholder="Untitled"
 					size="large"
 				/>

--- a/client/src/components/scrum/ScrumTabMain.tsx
+++ b/client/src/components/scrum/ScrumTabMain.tsx
@@ -1,5 +1,6 @@
 import type { ScrumGetResponse } from "@scr4m/common";
-import { ScrumTitle } from "./ScrumTitle";
+import { useState } from "react";
+import { TextArea } from "../TextArea";
 
 export type ScrumTabMainTitle = {
 	scrum: ScrumGetResponse;
@@ -8,12 +9,14 @@ export type ScrumTabMainTitle = {
 const ScrumTabMainTitle = (props: ScrumTabMainTitle) => {
 	const { scrum } = props;
 
+	const [title, setTitle] = useState<string>(scrum.title);
+
 	return (
 		<>
 			<h1 className="text-8xl mb-3">Scrum #{scrum.number}</h1>
-			<p className="text-2xl">
-				<ScrumTitle title={scrum.title} />
-			</p>{" "}
+			<div className="text-2xl">
+				<TextArea value={title} onChange={setTitle} placeholder="Untitled" />
+			</div>
 		</>
 	);
 };

--- a/client/src/components/scrum/ScrumTabMain.tsx
+++ b/client/src/components/scrum/ScrumTabMain.tsx
@@ -15,7 +15,12 @@ const ScrumTabMainTitle = (props: ScrumTabMainTitle) => {
 		<>
 			<h1 className="text-8xl mb-3">Scrum #{scrum.number}</h1>
 			<div className="text-2xl">
-				<TextArea value={title} onChange={setTitle} placeholder="Untitled" />
+				<TextArea
+					value={title}
+					onChange={setTitle}
+					placeholder="Untitled"
+					size="large"
+				/>
 			</div>
 		</>
 	);

--- a/client/src/components/scrum/ScrumTabMain.tsx
+++ b/client/src/components/scrum/ScrumTabMain.tsx
@@ -11,7 +11,7 @@ const ScrumTabMainTitle = (props: ScrumTabMainTitle) => {
 	return (
 		<>
 			<h1 className="text-8xl mb-3">Scrum #{scrum.number}</h1>
-			<p className="text-xl">
+			<p className="text-2xl">
 				<ScrumTitle title={scrum.title} />
 			</p>{" "}
 		</>

--- a/client/src/components/scrum/ScrumTabMain.tsx
+++ b/client/src/components/scrum/ScrumTabMain.tsx
@@ -17,6 +17,7 @@ const ScrumTabMainTitle = (props: ScrumTabMainTitle) => {
 					onChange={() => {}}
 					placeholder="Untitled"
 					size="large"
+					allowNewlines
 				/>
 			</div>
 		</>

--- a/client/src/components/scrum/ScrumTabMember.tsx
+++ b/client/src/components/scrum/ScrumTabMember.tsx
@@ -3,6 +3,7 @@ import type {
 	ScrumGetMember,
 	ScrumGetResponse,
 } from "@scr4m/common";
+import { TextArea } from "../TextArea";
 
 type ScrumTabMemberProps = {
 	scrum: ScrumGetResponse;
@@ -83,17 +84,32 @@ export const ScrumTabMember = (props: ScrumTabMemberProps) => {
 					return (
 						<>
 							{todid ? (
-								<ScrumCell key={`${todid.id}-todid`}>{todid.body}</ScrumCell>
+								<TextArea
+									key={`${todid.id}-todid`}
+									value="TBD"
+									onChange={() => {}}
+									size="default"
+								/>
 							) : (
 								<div key="none" />
 							)}
 							{did ? (
-								<ScrumCell key={`${did.id}-did`}>{did.body}</ScrumCell>
+								<TextArea
+									key={`${did.id}-did`}
+									value={did.body}
+									onChange={() => {}}
+									size="default"
+								/>
 							) : (
 								<div key="none" />
 							)}
 							{todo ? (
-								<ScrumCell key={`${todo.id}-todo`}>{todo.body}</ScrumCell>
+								<TextArea
+									key={`${todo.id}-todo`}
+									value={todo.body}
+									onChange={() => {}}
+									size="default"
+								/>
 							) : (
 								<div key="none" />
 							)}

--- a/client/src/components/scrum/ScrumTabMember.tsx
+++ b/client/src/components/scrum/ScrumTabMember.tsx
@@ -89,6 +89,7 @@ export const ScrumTabMember = (props: ScrumTabMemberProps) => {
 									value="TBD"
 									onChange={() => {}}
 									size="default"
+									disabled
 								/>
 							) : (
 								<div key="none" />

--- a/client/src/components/scrum/ScrumTabMember.tsx
+++ b/client/src/components/scrum/ScrumTabMember.tsx
@@ -54,15 +54,17 @@ export const ScrumTabMember = (props: ScrumTabMemberProps) => {
 		<>
 			<div className="mb-12">
 				<h1 className="text-8xl mb-3">{member.name}</h1>
-				<input
-					type="checkbox"
-					id="present-checkbox"
-					className="mr-3 accent-primary"
-					checked={member.present}
-				/>
-				<label htmlFor="present-checkbox" className="text-xl">
-					HERE
-				</label>
+				<div className="flex items-center">
+					<input
+						type="checkbox"
+						id="present-checkbox"
+						className="mr-3 accent-primary text-primary bg-secondary border-2 border-primary h-6 w-6"
+						checked={member.present}
+					/>
+					<label htmlFor="present-checkbox" className="text-2xl">
+						HERE
+					</label>
+				</div>
 			</div>
 			<div className="grid grid-cols-3 gap-x-6">
 				<ScrumCell>

--- a/client/src/components/scrum/ScrumTabMember.tsx
+++ b/client/src/components/scrum/ScrumTabMember.tsx
@@ -36,9 +36,7 @@ const reshapeEntries = (member: ScrumGetMember) => {
 };
 
 const ScrumCell = (props: React.PropsWithChildren) => {
-	return (
-		<div className="px-4 py-2 border-b border-primary">{props.children}</div>
-	);
+	return <div className="border-b border-primary">{props.children}</div>;
 };
 
 export const ScrumTabMember = (props: ScrumTabMemberProps) => {
@@ -67,7 +65,7 @@ export const ScrumTabMember = (props: ScrumTabMemberProps) => {
 					</label>
 				</div>
 			</div>
-			<div className="grid grid-cols-3 gap-x-6">
+			<div className="grid grid-cols-3 gap-x-6 auto-rows-min">
 				<ScrumCell>
 					<h1 className="text-center text-4xl mb-6">TODIDS</h1>
 				</ScrumCell>
@@ -84,33 +82,36 @@ export const ScrumTabMember = (props: ScrumTabMemberProps) => {
 					return (
 						<>
 							{todid ? (
-								<TextArea
-									key={`${todid.id}-todid`}
-									value="TBD"
-									onChange={() => {}}
-									size="default"
-									disabled
-								/>
+								<ScrumCell key={`${todid.id}-todid`}>
+									<TextArea
+										value="TBD"
+										onChange={() => {}}
+										size="default"
+										disabled
+									/>
+								</ScrumCell>
 							) : (
 								<div key="none" />
 							)}
 							{did ? (
-								<TextArea
-									key={`${did.id}-did`}
-									value={did.body}
-									onChange={() => {}}
-									size="default"
-								/>
+								<ScrumCell key={`${did.id}-did`}>
+									<TextArea
+										value={did.body}
+										onChange={() => {}}
+										size="default"
+									/>
+								</ScrumCell>
 							) : (
 								<div key="none" />
 							)}
 							{todo ? (
-								<TextArea
-									key={`${todo.id}-todo`}
-									value={todo.body}
-									onChange={() => {}}
-									size="default"
-								/>
+								<ScrumCell key={`${todo.id}-todo`}>
+									<TextArea
+										value={todo.body}
+										onChange={() => {}}
+										size="default"
+									/>
+								</ScrumCell>
 							) : (
 								<div key="none" />
 							)}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -23,5 +23,5 @@ export default {
 			},
 		},
 	},
-	plugins: [],
+	plugins: [require("@tailwindcss/forms")],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
         specifier: ^1.7.2
         version: 1.7.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@tailwindcss/forms':
+        specifier: ^0.5.9
+        version: 0.5.9(tailwindcss@3.4.4)
       '@tanstack/router-devtools':
         specifier: ^1.35.3
         version: 1.35.3(@tanstack/react-router@1.35.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -781,6 +784,11 @@ packages:
     resolution: {integrity: sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==}
     cpu: [x64]
     os: [win32]
+
+  '@tailwindcss/forms@0.5.9':
+    resolution: {integrity: sha512-tM4XVr2+UVTxXJzey9Twx48c1gcxFStqn1pQz0tRsX8o3DvxhN5oY5pvyAbUx7VTaZxpej4Zzvc6h+1RJBzpIg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20'
 
   '@tanstack/history@1.31.16':
     resolution: {integrity: sha512-rahAZXlR879P7dngDH7BZwGYiODA9D5Hqo6nUHn9GAURcqZU5IW0ZiT54dPtV5EPES7muZZmknReYueDHs7FFQ==}
@@ -1883,6 +1891,10 @@ packages:
   mimic-fn@3.1.0:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
+
+  mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
+    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -3402,6 +3414,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.17.2':
     optional: true
 
+  '@tailwindcss/forms@0.5.9(tailwindcss@3.4.4)':
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tailwindcss: 3.4.4
+
   '@tanstack/history@1.31.16': {}
 
   '@tanstack/query-core@5.40.0': {}
@@ -4596,6 +4613,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-fn@3.1.0: {}
+
+  mini-svg-data-uri@1.4.4: {}
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
Adds non-functional UI for scrum fields. Notably, replaces normal text elements for scrum entries titles, with custom <textareas>. Also installed the Tailwind forms plugin for styling.